### PR TITLE
reordering conditions

### DIFF
--- a/src/input/input_arc.c
+++ b/src/input/input_arc.c
@@ -79,7 +79,7 @@ int input_arc_read(hstring_t *strs, int len)
     int j = 0;
 
     /* Load block of files (no OpenMP here) */
-    while (archive_read_next_header(a, &entry) == ARCHIVE_OK && j < len) {
+    while (j < len && archive_read_next_header(a, &entry) == ARCHIVE_OK) {
         if (archive_entry_filetype(entry) != AE_IFREG) {
             archive_read_data_skip(a);
         } else {

--- a/src/input/input_dir.c
+++ b/src/input/input_dir.c
@@ -68,7 +68,7 @@ int input_dir_read(hstring_t *strs, int len)
     struct dirent *dp;
 
     /* Load block of files */
-    while (dir && (dp = readdir(dir)) != NULL && j < len) {
+    while (dir && j < len && (dp = readdir(dir)) != NULL) {
         /* Skip all entries except for regular files and symlinks */
         fix_dtype(path, dp);
         if (dp->d_type != DT_REG && dp->d_type != DT_LNK)


### PR DESCRIPTION
conditions in wrong order caused reading a new file without saving the reference. therefore each 256th file was skipped in an archive input e.g.