### PR TITLE
fix:doubled $(DESTDIR) in target dir in {,un}install-examplesDATA

### DIFF
--- a/examples/alexa/Makefile.am
+++ b/examples/alexa/Makefile.am
@@ -4,5 +4,5 @@
 EXTRA_DIST = alexa1000.txt figure_1.png figure_2.png run_example.sh \
              README.md most_similar.py
              
-examplesdir = $(DESTDIR)$(docdir)/alexa
+examplesdir = $(docdir)/alexa
 examples_DATA = $(EXTRA_DIST)

--- a/examples/reuters/Makefile.am
+++ b/examples/reuters/Makefile.am
@@ -3,5 +3,5 @@
 
 EXTRA_DIST = README.md harry.cfg reuters.zip run_example.sh
 
-examplesdir = $(DESTDIR)$(docdir)/reuters
+examplesdir = $(docdir)/reuters
 examples_DATA = $(EXTRA_DIST)


### PR DESCRIPTION
examplesdir = $(DESTDIR)$(docdir)/alexa  ##in examples/alexa/Makefile.am##
caused
-------
$(MKDIR_P) "$(DESTDIR)$(examplesdir)" => 
$(MKDIR_P) "$(DESTDIR)$(DESTDIR)$(docdir)/alexa" ##$(DESTDIR)$(DESTDIR) doubled here##
-------
in following examples/alexa/Makefile generated
install-examplesDATA: $(examples_DATA)
	@$(NORMAL_INSTALL)
	@list='$(examples_DATA)'; test -n "$(examplesdir)" || list=; \
	if test -n "$$list"; then \
	  echo " $(MKDIR_P) '$(DESTDIR)$(examplesdir)'"; \
	  $(MKDIR_P) "$(DESTDIR)$(examplesdir)" || exit 1; \
	fi; \
	for p in $$list; do \
	  if test -f "$$p"; then d=; else d="$(srcdir)/"; fi; \
	  echo "$$d$$p"; \
	done | $(am__base_list) | \
	while read files; do \
	  echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(examplesdir)'"; \
	  $(INSTALL_DATA) $$files "$(DESTDIR)$(examplesdir)" || exit $$?; \
	done

uninstall-examplesDATA:
	@$(NORMAL_UNINSTALL)
	@list='$(examples_DATA)'; test -n "$(examplesdir)" || list=; \
	files=`for p in $$list; do echo $$p; done | sed -e 's|^.*/||'`; \
	dir='$(DESTDIR)$(examplesdir)'; $(am__uninstall_files_from_dir)